### PR TITLE
ci: gate immutable release asset uploads [codex]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,8 +98,19 @@ jobs:
         with:
           name: pd-vm-cli-${{ runner.os }}-${{ runner.arch }}
           path: rustscript/dist/*
-      - name: Upload pd-vm CLI release asset
+      - name: Check release draft state
+        id: pd_vm_release_state
         if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${{ github.ref_name }}" --json isDraft --jq '.isDraft' >/tmp/release_is_draft; then
+            echo "is_draft=$(cat /tmp/release_is_draft)" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_draft=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Upload pd-vm CLI release asset
+        if: startsWith(github.ref, 'refs/tags/') && steps.pd_vm_release_state.outputs.is_draft == 'true'
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           files: rustscript/dist/*
@@ -133,8 +144,19 @@ jobs:
         with:
           name: rustscript-vscode-extension
           path: vscode-rustscript/dist/*.vsix
-      - name: Upload VS Code extension release asset
+      - name: Check VS Code release draft state
+        id: vscode_release_state
         if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "${{ github.ref_name }}" --json isDraft --jq '.isDraft' >/tmp/release_is_draft; then
+            echo "is_draft=$(cat /tmp/release_is_draft)" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_draft=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Upload VS Code extension release asset
+        if: startsWith(github.ref, 'refs/tags/') && steps.vscode_release_state.outputs.is_draft == 'true'
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           files: vscode-rustscript/dist/*.vsix


### PR DESCRIPTION
## Summary\n- Gate release asset uploads in CI behind a draft/publish check.\n- Skip `softprops/action-gh-release` when the tag release already exists and is published, which fails on immutable-release repos.\n\nThis keeps pd-vm CLI and VS Code artifact upload steps from breaking tagged CI runs while preserving normal upload behavior for new/draft releases.\n\nCloses #N/A