### PR TITLE
feat(host): infer typed host call contracts from signatures

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -49,6 +49,12 @@ pub(crate) enum HostBindingKind {
     StaticNonYieldingArgs,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum HostExecutionKind {
+    Sync,
+    MaySuspend,
+}
+
 impl HostBindingKind {
     pub(crate) fn render_bind_static_call(&self, name: &str, function_name: &str) -> String {
         let method = match self {
@@ -108,6 +114,7 @@ struct CallableDecl {
     static_return_type: String,
     wrapper: Option<WrapperDecl>,
     host_binding_kind: HostBindingKind,
+    host_execution: HostExecutionKind,
 }
 
 #[derive(Clone, Debug)]
@@ -261,7 +268,6 @@ pub(crate) fn classify_host_binding(function: &ItemFn) -> HostBindingKind {
         return HostBindingKind::StaticArgs;
     }
     if sole_type_argument(&return_type, "VmResult")
-        .or_else(|| sole_type_argument(&return_type, "HostResult"))
         .is_some_and(|inner| matches!(plain_path_type(&inner).as_deref(), Some("CallOutcome")))
     {
         return HostBindingKind::StaticArgs;
@@ -270,6 +276,22 @@ pub(crate) fn classify_host_binding(function: &ItemFn) -> HostBindingKind {
         return HostBindingKind::StaticNonYieldingArgs;
     }
     HostBindingKind::StaticArgs
+}
+
+pub(crate) fn infer_host_execution(function: &ItemFn) -> HostExecutionKind {
+    let return_type = normalized_return_type(&function.sig.output);
+    if contains_host_call_result(&return_type) {
+        HostExecutionKind::MaySuspend
+    } else {
+        HostExecutionKind::Sync
+    }
+}
+
+fn contains_host_call_result(ty: &Type) -> bool {
+    if sole_type_argument(ty, "HostCallResult").is_some() {
+        return true;
+    }
+    sole_type_argument(ty, "VmResult").is_some_and(|inner| contains_host_call_result(&inner))
 }
 
 fn is_supported_ordinary_return_type(ty: &Type) -> bool {
@@ -282,10 +304,8 @@ fn is_supported_ordinary_return_type(ty: &Type) -> bool {
                 return false;
             };
             match segment.ident.to_string().as_str() {
-                "Option" | "VmResult" | "HostResult" => {
-                    sole_type_argument(ty, &segment.ident.to_string())
-                        .is_some_and(|inner| is_supported_ordinary_return_type(&inner))
-                }
+                "Option" | "VmResult" => sole_type_argument(ty, &segment.ident.to_string())
+                    .is_some_and(|inner| is_supported_ordinary_return_type(&inner)),
                 "Vec" => sole_type_argument(ty, "Vec")
                     .is_some_and(|inner| is_supported_vec_return_type(&inner)),
                 "Value" | "bool" | "i64" | "u32" | "usize" | "f64" | "String" | "str"
@@ -404,6 +424,7 @@ fn parse_source_file(path: &Path, spec: &SourceSpec, _order_offset: usize) -> Ve
             static_return_type: static_return_type_label(&function.sig.output),
             wrapper,
             host_binding_kind: classify_host_binding(function),
+            host_execution: infer_host_execution(function),
         });
     }
     out
@@ -1145,9 +1166,13 @@ fn render_callable_consts(callables: &[&CallableDecl]) -> String {
         .unwrap();
         writeln!(
             &mut out,
-            "#[allow(dead_code)]\nconst {base}_DEF: CallableDef = CallableDef {{ name: {:?}, docs: {:?}, signature: {base}_SIGNATURE }};",
+            "#[allow(dead_code)]\nconst {base}_DEF: CallableDef = CallableDef {{ name: {:?}, docs: {:?}, signature: {base}_SIGNATURE, host_execution: HostExecution::{} }};",
             callable.name,
-            callable.docs
+            callable.docs,
+            match callable.host_execution {
+                HostExecutionKind::Sync => "Sync",
+                HostExecutionKind::MaySuspend => "MaySuspend",
+            }
         )
         .unwrap();
         writeln!(&mut out).unwrap();
@@ -1997,7 +2022,7 @@ fn type_label(ty: &Type) -> String {
                     };
                     format!("{} | null", type_label(inner))
                 }
-                "VmResult" | "BuiltinResult" | "HostResult" => {
+                "VmResult" | "HostCallResult" => {
                     let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
                         panic!("{ident}<T> requires one generic argument");
                     };

--- a/docs/plans/2026-07-16-automatic-host-binding-selection.md
+++ b/docs/plans/2026-07-16-automatic-host-binding-selection.md
@@ -67,7 +67,7 @@ Run the narrow host/JIT tests. Expected: generated code still selects `bind_stat
 Add `HostBindingKind::{StaticStack, StaticArgs, StaticNonYieldingArgs}` in `build.rs`. Classify in this order:
 
 1. any `Vm` parameter → `StaticStack`;
-2. normalized `CallOutcome`, including `VmResult<CallOutcome>` and `HostResult<CallOutcome>` → `StaticArgs`;
+2. normalized `CallOutcome`, including `VmResult<CallOutcome>` → `StaticArgs`;
 3. all other valid args-only returns → `StaticNonYieldingArgs`.
 
 Use that one classification in generated registry and direct VM binding code. The non-yielding branches must emit `register_static_non_yielding_args` and `bind_static_non_yielding_args_function`.

--- a/docs/superpowers/specs/2026-07-16-automatic-host-binding-selection-design.md
+++ b/docs/superpowers/specs/2026-07-16-automatic-host-binding-selection-design.md
@@ -13,10 +13,10 @@ This change covers `#[pd_host_function]` implementations discovered by the RustS
 Introduce one shared build-time classification with these ordered rules:
 
 1. A function with a `Vm` context parameter uses `StaticStack`.
-2. An args-only function whose normalized return type is `CallOutcome`, including `VmResult<CallOutcome>` and `HostResult<CallOutcome>`, uses `StaticArgs`.
+2. An args-only function whose normalized return type is `CallOutcome`, including `VmResult<CallOutcome>`, uses `StaticArgs`.
 3. Every other valid args-only annotated function uses `StaticNonYieldingArgs`.
 
-The third rule is safe because the generated wrapper converts all supported ordinary outputs through `IntoVmValue` into exactly one `Value`. This includes implicit `()`, explicit `()`, and `Option<T>`, which become `Value::Null` when appropriate. `VmResult<T>` and `HostResult<T>` may still return an error; successful calls return exactly one value synchronously.
+The third rule is safe because the generated wrapper converts all supported ordinary outputs through `IntoVmValue` into exactly one `Value`. This includes implicit `()`, explicit `()`, and `Option<T>`, which become `Value::Null` when appropriate. `VmResult<T>` may still return an error; successful calls return exactly one value synchronously.
 
 `CallOutcome` stays on the general static args ABI because it can represent no return value, halt, yield, or pending work. Any signature that cannot be classified safely falls back to the general compatible static binding.
 

--- a/pd-host-function/src/lib.rs
+++ b/pd-host-function/src/lib.rs
@@ -53,6 +53,16 @@ fn parse_name_arg(args: &Punctuated<Meta, Token![,]>) -> Result<LitStr, Error> {
             "expected #[pd_host_function(name = \"...\")]",
         ));
     };
+    if args.len() != 1 {
+        let extra = args
+            .iter()
+            .nth(1)
+            .expect("a non-empty attribute with more than one argument has an extra argument");
+        return Err(Error::new_spanned(
+            extra,
+            "#[pd_host_function] only supports name = \"...\"",
+        ));
+    }
     if !name_value.path.is_ident("name") {
         return Err(Error::new_spanned(
             &name_value.path,
@@ -267,10 +277,7 @@ fn unwrap_vm_result_type(ty: &Type) -> Result<Option<Type>, Error> {
             let Some(segment) = path.path.segments.last() else {
                 return Ok(None);
             };
-            if !matches!(
-                segment.ident.to_string().as_str(),
-                "VmResult" | "HostResult"
-            ) {
+            if segment.ident != "VmResult" {
                 return Ok(None);
             }
             let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
@@ -352,7 +359,7 @@ fn type_label(ty: &Type) -> Result<String, Error> {
                     let inner_label = type_label(inner)?;
                     Ok(format!("{inner_label} | null"))
                 }
-                "VmResult" | "BuiltinResult" | "HostResult" => {
+                "VmResult" | "HostCallResult" => {
                     let syn::PathArguments::AngleBracketed(args) = &segment.arguments else {
                         return Err(Error::new_spanned(
                             &segment.arguments,
@@ -470,5 +477,60 @@ fn uses_taken_extractor(ty: &Type) -> bool {
             )
         }),
         _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::expand_pd_host_function;
+    use syn::{ItemFn, Meta, Token, parse_quote, punctuated::Punctuated};
+
+    #[test]
+    fn accepts_host_call_result_from_the_function_signature() {
+        let attr: Punctuated<Meta, Token![,]> = parse_quote!(name = "test::suspend");
+        let item: ItemFn = parse_quote! {
+            /// Returns a value after a host operation completes.
+            #[pd_host_function(name = "test::suspend")]
+            fn suspend() -> VmResult<HostCallResult<Value>> {
+                todo!()
+            }
+        };
+
+        let expanded = expand_pd_host_function(attr, item)
+            .expect("HostCallResult should be accepted from the return signature");
+        assert!(expanded.to_string().contains("HostCallResult"));
+    }
+
+    #[test]
+    fn rejects_host_result_compatibility_wrapper() {
+        let attr: Punctuated<Meta, Token![,]> = parse_quote!(name = "test::legacy");
+        let item: ItemFn = parse_quote! {
+            /// Legacy result wrapper must be rejected.
+            #[pd_host_function(name = "test::legacy")]
+            fn legacy() -> HostResult<Value> {
+                todo!()
+            }
+        };
+
+        let error = expand_pd_host_function(attr, item)
+            .expect_err("HostResult must not be accepted as a return wrapper");
+        assert!(error.to_string().contains("unsupported callable type"));
+    }
+
+    #[test]
+    fn rejects_async_attribute_instead_of_treating_it_as_a_host_contract() {
+        let attr: Punctuated<Meta, Token![,]> =
+            parse_quote!(name = "test::suspend", r#async = true);
+        let item: ItemFn = parse_quote! {
+            /// Returns a value after a host operation completes.
+            #[pd_host_function(name = "test::suspend")]
+            fn suspend() -> VmResult<HostCallResult<Value>> {
+                todo!()
+            }
+        };
+
+        let error = expand_pd_host_function(attr, item)
+            .expect_err("the pd-host-function macro must not accept an async attribute");
+        assert!(error.to_string().contains("only supports name"));
     }
 }

--- a/src/builtins/metadata.rs
+++ b/src/builtins/metadata.rs
@@ -43,10 +43,17 @@ pub struct CallableSignature {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum HostExecution {
+    Sync,
+    MaySuspend,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct CallableDef {
     pub name: &'static str,
     pub docs: &'static str,
     pub signature: CallableSignature,
+    pub host_execution: HostExecution,
 }
 
 #[allow(dead_code)]

--- a/src/builtins/mod.rs
+++ b/src/builtins/mod.rs
@@ -5,7 +5,9 @@ mod metadata;
 #[cfg(feature = "runtime")]
 pub(crate) mod runtime;
 
-pub use self::metadata::{CallableDef, CallableParam, CallableParamType, CallableSignature};
+pub use self::metadata::{
+    CallableDef, CallableParam, CallableParamType, CallableSignature, HostExecution,
+};
 use crate::ValueType;
 #[cfg(feature = "runtime")]
 pub(crate) use crate::vm::{HostFunctionRegistry, Value, Vm, VmResult};

--- a/src/builtins/runtime/io.rs
+++ b/src/builtins/runtime/io.rs
@@ -9,7 +9,7 @@ use std::task::{Context, Poll};
 use futures_channel::oneshot;
 use pd_host_function::pd_host_function;
 
-use super::BuiltinResult;
+use super::HostCallResult;
 use crate::vm::{CallReturn, HostOpId, Value, Vm, VmError, VmResult};
 
 pub(crate) struct IoState {
@@ -87,7 +87,11 @@ pub(super) fn close_all_handles(vm: &mut Vm) {
 
 /// Opens a file handle for runtime I/O.
 #[pd_host_function(name = "io::open")]
-pub(super) fn builtin_io_open(vm: &mut Vm, path: &str, mode: &str) -> VmResult<BuiltinResult<i64>> {
+pub(super) fn builtin_io_open(
+    vm: &mut Vm,
+    path: &str,
+    mode: &str,
+) -> VmResult<HostCallResult<i64>> {
     let reserved_id = io_reserve_handle_id(vm);
     let path = path.to_string();
     let mode = mode.to_string();
@@ -133,7 +137,7 @@ pub(super) fn builtin_io_open(vm: &mut Vm, path: &str, mode: &str) -> VmResult<B
             },
         }
     })?;
-    Ok(BuiltinResult::Pending(op_id))
+    Ok(HostCallResult::Pending(op_id))
 }
 
 /// Starts a child process and returns a process-backed handle.
@@ -142,7 +146,7 @@ pub(super) fn builtin_io_popen(
     vm: &mut Vm,
     command: &str,
     mode: &str,
-) -> VmResult<BuiltinResult<i64>> {
+) -> VmResult<HostCallResult<i64>> {
     if mode != "r" && mode != "w" {
         return Err(VmError::HostError(format!(
             "unsupported io_popen mode '{mode}', expected r or w"
@@ -191,12 +195,12 @@ pub(super) fn builtin_io_popen(
             result: Ok(CallReturn::one(Value::Int(reserved_id))),
         }
     })?;
-    Ok(BuiltinResult::Pending(op_id))
+    Ok(HostCallResult::Pending(op_id))
 }
 
 /// Reads all remaining text from an I/O handle.
 #[pd_host_function(name = "io::read_all")]
-pub(super) fn builtin_io_read_all(vm: &mut Vm, handle_id: i64) -> VmResult<BuiltinResult<String>> {
+pub(super) fn builtin_io_read_all(vm: &mut Vm, handle_id: i64) -> VmResult<HostCallResult<String>> {
     let handle = io_take_handle(vm, handle_id)?;
     let op_id = schedule_io_task(vm, move || {
         let mut handle = handle;
@@ -232,12 +236,15 @@ pub(super) fn builtin_io_read_all(vm: &mut Vm, handle_id: i64) -> VmResult<Built
             result,
         }
     })?;
-    Ok(BuiltinResult::Pending(op_id))
+    Ok(HostCallResult::Pending(op_id))
 }
 
 /// Reads a single line of text from an I/O handle.
 #[pd_host_function(name = "io::read_line")]
-pub(super) fn builtin_io_read_line(vm: &mut Vm, handle_id: i64) -> VmResult<BuiltinResult<String>> {
+pub(super) fn builtin_io_read_line(
+    vm: &mut Vm,
+    handle_id: i64,
+) -> VmResult<HostCallResult<String>> {
     let handle = io_take_handle(vm, handle_id)?;
     let op_id = schedule_io_task(vm, move || {
         let mut handle = handle;
@@ -268,7 +275,7 @@ pub(super) fn builtin_io_read_line(vm: &mut Vm, handle_id: i64) -> VmResult<Buil
             result,
         }
     })?;
-    Ok(BuiltinResult::Pending(op_id))
+    Ok(HostCallResult::Pending(op_id))
 }
 
 /// Writes text to an I/O handle.
@@ -277,7 +284,7 @@ pub(super) fn builtin_io_write(
     vm: &mut Vm,
     handle_id: i64,
     text: &str,
-) -> VmResult<BuiltinResult<i64>> {
+) -> VmResult<HostCallResult<i64>> {
     let bytes = text.as_bytes().to_vec();
     let handle = io_take_handle(vm, handle_id)?;
     let op_id = schedule_io_task(vm, move || {
@@ -313,12 +320,12 @@ pub(super) fn builtin_io_write(
             result,
         }
     })?;
-    Ok(BuiltinResult::Pending(op_id))
+    Ok(HostCallResult::Pending(op_id))
 }
 
 /// Flushes buffered output for an I/O handle.
 #[pd_host_function(name = "io::flush")]
-pub(super) fn builtin_io_flush(vm: &mut Vm, handle_id: i64) -> VmResult<BuiltinResult<bool>> {
+pub(super) fn builtin_io_flush(vm: &mut Vm, handle_id: i64) -> VmResult<HostCallResult<bool>> {
     let handle = io_take_handle(vm, handle_id)?;
     let op_id = schedule_io_task(vm, move || {
         let mut handle = handle;
@@ -351,23 +358,23 @@ pub(super) fn builtin_io_flush(vm: &mut Vm, handle_id: i64) -> VmResult<BuiltinR
             result,
         }
     })?;
-    Ok(BuiltinResult::Pending(op_id))
+    Ok(HostCallResult::Pending(op_id))
 }
 
 /// Closes an I/O handle.
 #[pd_host_function(name = "io::close")]
-pub(super) fn builtin_io_close(vm: &mut Vm, handle_id: i64) -> VmResult<BuiltinResult<bool>> {
+pub(super) fn builtin_io_close(vm: &mut Vm, handle_id: i64) -> VmResult<HostCallResult<bool>> {
     let handle = io_take_handle(vm, handle_id)?;
     let op_id = schedule_io_task(vm, move || IoAsyncCompletion {
         restored_handle: None,
         result: close_io_handle(handle).map(|_| CallReturn::one(Value::Bool(true))),
     })?;
-    Ok(BuiltinResult::Pending(op_id))
+    Ok(HostCallResult::Pending(op_id))
 }
 
 /// Returns whether a file system path exists.
 #[pd_host_function(name = "io::exists")]
-pub(super) fn builtin_io_exists(vm: &mut Vm, path: &str) -> VmResult<BuiltinResult<bool>> {
+pub(super) fn builtin_io_exists(vm: &mut Vm, path: &str) -> VmResult<HostCallResult<bool>> {
     let path = path.to_string();
     let op_id = schedule_io_task(vm, move || IoAsyncCompletion {
         restored_handle: None,
@@ -375,7 +382,7 @@ pub(super) fn builtin_io_exists(vm: &mut Vm, path: &str) -> VmResult<BuiltinResu
             std::path::Path::new(path.as_str()).exists(),
         ))),
     })?;
-    Ok(BuiltinResult::Pending(op_id))
+    Ok(HostCallResult::Pending(op_id))
 }
 
 fn spawn_shell_command(command: &str, mode: &str) -> VmResult<Child> {

--- a/src/builtins/runtime/io_wasm.rs
+++ b/src/builtins/runtime/io_wasm.rs
@@ -2,7 +2,7 @@ use std::task::{Context, Poll};
 
 use pd_host_function::pd_host_function;
 
-use super::BuiltinResult;
+use super::HostCallResult;
 use crate::vm::{CallReturn, HostOpId, Value, Vm, VmError, VmResult};
 
 pub(crate) struct IoState;
@@ -31,7 +31,7 @@ pub(super) fn builtin_io_open(
     _vm: &mut Vm,
     _path: &str,
     _mode: &str,
-) -> VmResult<BuiltinResult<i64>> {
+) -> VmResult<HostCallResult<i64>> {
     Err(VmError::HostError(
         "io::open is unsupported on wasm32 runtime".to_string(),
     ))
@@ -43,7 +43,7 @@ pub(super) fn builtin_io_popen(
     _vm: &mut Vm,
     _command: &str,
     _mode: &str,
-) -> VmResult<BuiltinResult<i64>> {
+) -> VmResult<HostCallResult<i64>> {
     Err(VmError::HostError(
         "io::popen is unsupported on wasm32 runtime".to_string(),
     ))
@@ -54,7 +54,7 @@ pub(super) fn builtin_io_popen(
 pub(super) fn builtin_io_read_all(
     _vm: &mut Vm,
     _handle_id: i64,
-) -> VmResult<BuiltinResult<String>> {
+) -> VmResult<HostCallResult<String>> {
     Err(VmError::HostError(
         "io::read_all is unsupported on wasm32 runtime".to_string(),
     ))
@@ -65,7 +65,7 @@ pub(super) fn builtin_io_read_all(
 pub(super) fn builtin_io_read_line(
     _vm: &mut Vm,
     _handle_id: i64,
-) -> VmResult<BuiltinResult<String>> {
+) -> VmResult<HostCallResult<String>> {
     Err(VmError::HostError(
         "io::read_line is unsupported on wasm32 runtime".to_string(),
     ))
@@ -77,7 +77,7 @@ pub(super) fn builtin_io_write(
     _vm: &mut Vm,
     _handle_id: i64,
     _text: &str,
-) -> VmResult<BuiltinResult<i64>> {
+) -> VmResult<HostCallResult<i64>> {
     Err(VmError::HostError(
         "io::write is unsupported on wasm32 runtime".to_string(),
     ))
@@ -85,7 +85,7 @@ pub(super) fn builtin_io_write(
 
 /// Flushes buffered output for an I/O handle.
 #[pd_host_function(name = "io::flush")]
-pub(super) fn builtin_io_flush(_vm: &mut Vm, _handle_id: i64) -> VmResult<BuiltinResult<bool>> {
+pub(super) fn builtin_io_flush(_vm: &mut Vm, _handle_id: i64) -> VmResult<HostCallResult<bool>> {
     Err(VmError::HostError(
         "io::flush is unsupported on wasm32 runtime".to_string(),
     ))
@@ -93,7 +93,7 @@ pub(super) fn builtin_io_flush(_vm: &mut Vm, _handle_id: i64) -> VmResult<Builti
 
 /// Closes an I/O handle.
 #[pd_host_function(name = "io::close")]
-pub(super) fn builtin_io_close(_vm: &mut Vm, _handle_id: i64) -> VmResult<BuiltinResult<bool>> {
+pub(super) fn builtin_io_close(_vm: &mut Vm, _handle_id: i64) -> VmResult<HostCallResult<bool>> {
     Err(VmError::HostError(
         "io::close is unsupported on wasm32 runtime".to_string(),
     ))
@@ -101,7 +101,7 @@ pub(super) fn builtin_io_close(_vm: &mut Vm, _handle_id: i64) -> VmResult<Builti
 
 /// Returns whether a file system path exists.
 #[pd_host_function(name = "io::exists")]
-pub(super) fn builtin_io_exists(_vm: &mut Vm, _path: &str) -> VmResult<BuiltinResult<bool>> {
+pub(super) fn builtin_io_exists(_vm: &mut Vm, _path: &str) -> VmResult<HostCallResult<bool>> {
     Err(VmError::HostError(
         "io::exists is unsupported on wasm32 runtime".to_string(),
     ))

--- a/src/builtins/runtime/mod.rs
+++ b/src/builtins/runtime/mod.rs
@@ -25,9 +25,10 @@ mod typed;
 use io_wasm as io;
 
 pub(crate) use io::IoState;
+pub use typed::HostCallResult;
 use typed::{
-    AnyValue, BuiltinResult, IntoBuiltinCallOutcome, IntoHostCallOutcome, NumberValue,
-    UnknownValue, VmArray, VmBytes, VmMap, arg, borrow_arg, return_none, return_one, take_arg,
+    AnyValue, IntoBuiltinCallOutcome, IntoHostCallOutcome, NumberValue, UnknownValue, VmArray,
+    VmBytes, VmMap, arg, borrow_arg, return_none, return_one, take_arg,
 };
 
 pub(crate) enum BuiltinCallOutcome {

--- a/src/builtins/runtime/typed.rs
+++ b/src/builtins/runtime/typed.rs
@@ -35,6 +35,12 @@ impl NumberValue {
     }
 }
 
+#[derive(Debug, PartialEq)]
+pub enum HostCallResult<T> {
+    Return(T),
+    Pending(HostOpId),
+}
+
 pub(super) fn missing_arg(label: &str) -> VmError {
     VmError::HostError(format!("missing argument: {label}"))
 }
@@ -447,13 +453,7 @@ where
     }
 }
 
-#[allow(dead_code)]
-pub(super) enum BuiltinResult<T> {
-    Return(T),
-    Pending(HostOpId),
-}
-
-impl<T> IntoBuiltinCallOutcome for BuiltinResult<T>
+impl<T> IntoBuiltinCallOutcome for HostCallResult<T>
 where
     T: IntoVmValue,
 {
@@ -475,6 +475,18 @@ impl IntoHostCallOutcome for CallOutcome {
     }
 }
 
+impl<T> IntoHostCallOutcome for HostCallResult<T>
+where
+    T: IntoVmValue,
+{
+    fn into_host_call_outcome(self) -> CallOutcome {
+        match self {
+            Self::Return(value) => value.into_host_call_outcome(),
+            Self::Pending(op_id) => CallOutcome::Pending(op_id),
+        }
+    }
+}
+
 impl<T> IntoHostCallOutcome for T
 where
     T: IntoVmValue,
@@ -486,7 +498,10 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{Value, arg};
+    use super::{
+        BuiltinCallOutcome, HostCallResult, IntoBuiltinCallOutcome, IntoHostCallOutcome, Value, arg,
+    };
+    use crate::vm::{CallOutcome, CallReturn};
 
     #[test]
     fn optional_arg_decodes_missing_as_none() {
@@ -510,5 +525,23 @@ mod tests {
         let value =
             arg::<Option<&str>>(&args, 0, "label").expect("present optional arg should decode");
         assert_eq!(value, Some("hello"));
+    }
+
+    #[test]
+    fn host_call_result_converts_return_and_pending_variants() {
+        assert_eq!(
+            HostCallResult::Return(true).into_host_call_outcome(),
+            CallOutcome::Return(CallReturn::one(Value::Bool(true)))
+        );
+        assert_eq!(
+            HostCallResult::<Value>::Pending(17).into_host_call_outcome(),
+            CallOutcome::Pending(17)
+        );
+    }
+
+    #[test]
+    fn host_call_result_is_the_builtin_pending_result() {
+        let outcome = HostCallResult::<Value>::Pending(23).into_builtin_call_outcome();
+        assert!(matches!(outcome, BuiltinCallOutcome::Pending(23)));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,13 @@ pub mod vmbc;
 
 pub use assembler::{AsmParseError, Assembler, AssemblerError, BytecodeBuilder, assemble};
 #[cfg(feature = "runtime")]
+pub use builtins::runtime::HostCallResult;
+#[cfg(feature = "runtime")]
 pub use builtins::runtime::print::{PrintHostFunction, PrintlnHostFunction, format_value};
 pub use builtins::{
     BUILTIN_CATALOG, BuiltinFunction, BuiltinNamespaceMemberSpec, BuiltinNamespaceSpec,
-    CallableDef, CallableParam, CallableParamType, CallableSignature, LanguageBuiltinSpec,
-    builtin_namespace_specs, callable_signatures_for_builtin_namespace_member,
+    CallableDef, CallableParam, CallableParamType, CallableSignature, HostExecution,
+    LanguageBuiltinSpec, builtin_namespace_specs, callable_signatures_for_builtin_namespace_member,
     default_host_callables, is_builtin_namespace, language_builtin_specs,
     resolve_builtin_namespace_call,
 };

--- a/tests/host_binding_generation_tests.rs
+++ b/tests/host_binding_generation_tests.rs
@@ -2,7 +2,9 @@
 #[path = "../build.rs"]
 mod build_script;
 
-use build_script::{HostBindingKind, classify_host_binding};
+use build_script::{
+    HostBindingKind, HostExecutionKind, classify_host_binding, infer_host_execution,
+};
 use syn::parse_quote;
 use vm::{HostFunctionRegistry, JitConfig, JitTraceTerminal, Value, Vm, VmStatus, compile_source};
 
@@ -37,9 +39,6 @@ fn classifies_best_effort_host_bindings_from_signatures() {
             fn host() -> VmResult<CallOutcome> {}
         ),
         parse_quote!(
-            fn host() -> HostResult<CallOutcome> {}
-        ),
-        parse_quote!(
             fn host() -> (VmResult<&CallOutcome>) {}
         ),
     ] {
@@ -64,9 +63,6 @@ fn classifies_best_effort_host_bindings_from_signatures() {
         ),
         parse_quote!(
             fn host() -> VmResult<bool> {}
-        ),
-        parse_quote!(
-            fn host() -> HostResult<String> {}
         ),
         parse_quote!(
             fn host() -> Value {}
@@ -118,6 +114,32 @@ fn classifies_best_effort_host_bindings_from_signatures() {
             HostBindingKind::StaticArgs
         );
     }
+}
+
+#[test]
+fn infers_host_suspension_from_the_return_signature() {
+    for function in [
+        parse_quote!(
+            fn host() -> HostCallResult<Value> {}
+        ),
+        parse_quote!(
+            fn host() -> VmResult<HostCallResult<Value>> {}
+        ),
+    ] {
+        assert_eq!(
+            infer_host_execution(&function),
+            HostExecutionKind::MaySuspend
+        );
+        assert_eq!(
+            classify_host_binding(&function),
+            HostBindingKind::StaticArgs
+        );
+    }
+
+    let synchronous = parse_quote!(
+        fn host() -> VmResult<Value> {}
+    );
+    assert_eq!(infer_host_execution(&synchronous), HostExecutionKind::Sync);
 }
 
 fn assert_runtime_sleep_loop_uses_native_host_call(bind_cached_registry: bool) {


### PR DESCRIPTION
## Summary
- infer host binding kind, return schema, and suspension behavior from Rust signatures
- use `VmResult<T>` for VM errors and `HostCallResult<T>` for return-or-pending behavior
- remove `BuiltinResult<T>` and reject the undefined `HostResult<T>` wrapper across generation and macros

## Stack
Layer 1 of 14  
Next: #13

## Validation
- `cargo test --locked -p pd-host-function`
- `cargo test --locked --test host_binding_generation_tests`
- `cargo test --locked --test builtins_tests`
